### PR TITLE
Support north/south VPC connectivity. Readme clarification.

### DIFF
--- a/PacketHeader.cpp
+++ b/PacketHeader.cpp
@@ -60,7 +60,10 @@ PacketHeader::PacketHeader(unsigned char *pktbuf, ssize_t pktlen)
  */
 bool PacketHeader::operator==(const PacketHeader &ph) const
 {
-    return prot == ph.prot && src == ph.src && dst == ph.dst && srcpt == ph.srcpt && dstpt == ph.dstpt;
+    // also allowing return traffic
+    return prot == ph.prot &&
+           ((src == ph.src && dst == ph.dst) || (src == ph.dst && dst == ph.src)) &&
+           ((srcpt == ph.srcpt && dstpt == ph.dstpt) || (srcpt == ph.dstpt && dstpt == ph.srcpt));
 }
 
 /**

--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ Example: ./gwlbtun
   -x         Enable dumping the hex payload of packets being processed.
 
 ---------------------------------------------------------------------------------------------------------
-Tunnel command arguments:
-The commands will be called with the following arguments:
+
+Hook scripts arguments:
+These arguments are provided to the hook scripts (provided by the -c <FILE> or -r <FILE> command options).
+On gwlbtun startup, it will automatically create gwi-<X> and gwo-<X> interfaces upon seeing the first packet from a specific GWLBE, and the hook scripts are invoked when interfaces are created or destroyed. You should at least disable rpf_filter for the gwi-<X> tunnel interface with the hook scripts.
+The hook scripts will be called with the following arguments:
 1: The string 'CREATE' or 'DESTROY', depending on which operation is occurring.
 2: The interface name of the ingress interface (gwi-<X>).
 3: The interface name of the egress interface (gwo-<X>).  Packets can be sent out via in the ingress

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example: ./gwlbtun
 ---------------------------------------------------------------------------------------------------------
 
 Hook scripts arguments:
-These arguments are provided to the hook scripts (provided by the -c <FILE> or -r <FILE> command options).
+These arguments are provided when gwlbtun calls the hook scripts (the scrpits are in the -c <FILE> or -r <FILE> command options).
 On gwlbtun startup, it will automatically create gwi-<X> and gwo-<X> interfaces upon seeing the first packet from a specific GWLBE, and the hook scripts are invoked when interfaces are created or destroyed. You should at least disable rpf_filter for the gwi-<X> tunnel interface with the hook scripts.
 The hook scripts will be called with the following arguments:
 1: The string 'CREATE' or 'DESTROY', depending on which operation is occurring.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Support north/south VPC connectivity by allowing returning traffic. An example could be centralized NAT.
2. Made some clarifications in command line usage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
