### PR TITLE
Fix idle timeout for flow cache parameter

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -198,7 +198,7 @@ int main(int argc, char *argv[])
 
     // Argument parsing
     int optind;
-    while ((c = getopt_long (argc, argv, "h?djxc:r:t:p:s", long_options, &optind)) != -1)
+    while ((c = getopt_long (argc, argv, "h?djxc:r:t:p:si:", long_options, &optind)) != -1)
     {
         switch(c)
         {


### PR DESCRIPTION
*Description of changes:*
 
When attempting to use the `-i` parameter, I received the error: `invalid option -- 'i'`. This pull request fixes this error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
