### PR TITLE
fix(FlowCache): Update flow cache entry on every new inbound packet

### DIFF
--- a/GeneveHandler.cpp
+++ b/GeneveHandler.cpp
@@ -293,7 +293,7 @@ void GeneveHandlerENI::udpReceiverCallback(const GwlbData &gd, unsigned char *pk
 #ifndef NO_RETURN_TRAFFIC
                 auto ph = PacketHeaderV4(pkt + gd.gp.headerLen, pktlen - gd.gp.headerLen);
                 // Ensure flow is in flow cache.
-                auto gdret = gwlbV4Cookies.emplace_or_lookup(ph, gd);
+                gwlbV4Cookies.insert(std::move(ph), std::move(gd));
 #endif
                 // Route the decap'ed packet to our tun interface.
                 (*tunnelIn).writePacket(pkt + gd.gp.headerLen, pktlen - gd.gp.headerLen);
@@ -301,7 +301,7 @@ void GeneveHandlerENI::udpReceiverCallback(const GwlbData &gd, unsigned char *pk
 #ifndef NO_RETURN_TRAFFIC
                 auto ph = PacketHeaderV6(pkt + gd.gp.headerLen, pktlen - gd.gp.headerLen);
                 // Ensure flow is in flow cache.
-                auto gdret = gwlbV6Cookies.emplace_or_lookup(ph, gd);
+                gwlbV6Cookies.insert(std::move(ph), std::move(gd));
 #endif
                 // Route the decap'ed packet to our tun interface.
                 (*tunnelIn).writePacket(pkt + gd.gp.headerLen, pktlen - gd.gp.headerLen);


### PR DESCRIPTION
If a 5-tuple is reused within the cacheTimeout (defaults to 350s) but the Gateway Load Balancer recognizes it as a new flow with a new flow cookie, return packets would not be correctly handled and would be encapsulated with the wrong flow cookie value. This is a very common occurrence for workloads that have short-lived TCP connections and have aggressive source port reuse. New connections (identified by SYN packets) would lookup to potentially older TCP connection's flow cookie causing the Gateway Load Balancer to drop return SYN+ACK packets.

This PR addresses this issue by always updating the FlowCache with the latest value, even if it isn't different than in the cache. From my performance testing and profiling this wasn't a significant enough difference to warrant making anything more complex (with a compare and store behavior). But maintainers may want different behavior here.

This also removes the unused `useCount` property on the FlowCache otherwise it would have stored an invalid value due to the entry being replaced on each packet.

Making this change reduced the packet loss for high-flow-churn workloads from ~0.15% down to near 0%.