### PR TITLE
chore: Hot-path performance improvements

### DIFF
--- a/PacketHeaderV4.cpp
+++ b/PacketHeaderV4.cpp
@@ -13,9 +13,7 @@
 #include <netinet/udp.h>
 #include <netinet/tcp.h>
 #include <cstring>
-#include <typeindex>
 
-#include "utils.h"
 
 /**
  * Parse an IP packet header.
@@ -66,32 +64,6 @@ PacketHeaderV4::PacketHeaderV4(unsigned char *pktbuf, ssize_t pktlen)
 }
 
 /**
- * Compare if the headers in one packet match another. Meant to be used for the various sort and search functions.
- *
- * @param ph PacketHeaderV4 to compare againgst.
- * @return true if PacketHeaders are the same, false otherwise.
- */
-bool PacketHeaderV4::operator==(const PacketHeaderV4 &ph) const
-{
-#ifdef HASH_IS_SYMMETRICAL
-    return prot == ph.prot && ((src == ph.src && dst == ph.dst && srcpt == ph.srcpt && dstpt == ph.dstpt) ||
-                               (src == ph.dst && dst == ph.src && srcpt == ph.dstpt && dstpt == ph.srcpt));
-#else
-    return prot == ph.prot && src == ph.src && dst == ph.dst && srcpt == ph.srcpt && dstpt == ph.dstpt;
-#endif
-}
-
-/**
- * Returns a hash value based on the protocol data.
- *
- * @return Hash value.
- */
-std::size_t PacketHeaderV4::hash() const
-{
-    return hashFunc(prot, (void *)&src, (void *)&dst, 4, srcpt, dstpt);
-}
-
-/**
  * Returns a string with the contents of the PacketHeaderV4 for human consumption.
  *
  * @return The string.
@@ -126,16 +98,3 @@ std::ostream &operator<<(std::ostream &os, PacketHeaderV4 const &m)
 {
     return os << m.text();
 }
-
-/**
- * Extend std::hash for PacketHeaderV4
- */
-std::size_t std::hash<PacketHeaderV4>::operator()(const PacketHeaderV4& t) const
-{
-    return t.hash();
-};
-
-std::size_t hash_value(const PacketHeaderV4& t)
-{
-    return t.hash();
-};

--- a/PacketHeaderV4.h
+++ b/PacketHeaderV4.h
@@ -11,13 +11,39 @@
 #include <iostream>
 #include <stdexcept>
 #include <netinet/ip6.h>
+#include <typeindex>
+#include "utils.h"
 
 class PacketHeaderV4 {
 public:
     PacketHeaderV4(unsigned char *pktbuf, ssize_t pktlen);   // pktbuf points to the start of the IP header.
-    bool operator==(const PacketHeaderV4 &) const;
     std::string text() const;
-    std::size_t hash() const;
+
+    /**
+    * Compare if the headers in one packet match another. Meant to be used for the various sort and search functions.
+    *
+    * @param ph PacketHeaderV4 to compare againgst.
+    * @return true if PacketHeaders are the same, false otherwise.
+    */
+    bool operator==(const PacketHeaderV4 &ph) const
+    {
+    #ifdef HASH_IS_SYMMETRICAL
+        return prot == ph.prot && ((src == ph.src && dst == ph.dst && srcpt == ph.srcpt && dstpt == ph.dstpt) ||
+                                (src == ph.dst && dst == ph.src && srcpt == ph.dstpt && dstpt == ph.srcpt));
+    #else
+        return prot == ph.prot && src == ph.src && dst == ph.dst && srcpt == ph.srcpt && dstpt == ph.dstpt;
+    #endif
+    }
+
+    /**
+    * Returns a hash value based on the protocol data.
+    *
+    * @return Hash value.
+    */
+    std::size_t hash() const
+    {
+        return hashFunc(prot, (void *)&src, (void *)&dst, 4, srcpt, dstpt);
+    }
 
 private:
     uint32_t  src;
@@ -28,7 +54,20 @@ private:
 };
 
 std::ostream &operator<<(std::ostream &os, PacketHeaderV4 const &m);
-template<> struct std::hash<PacketHeaderV4>:unary_function<PacketHeaderV4, size_t> { std::size_t operator()(const PacketHeaderV4& t) const; };
-std::size_t hash_value(const PacketHeaderV4& t);
+
+template<> struct std::hash<PacketHeaderV4>:unary_function<PacketHeaderV4, size_t> { 
+    std::size_t operator()(const PacketHeaderV4& t) const
+    {
+        return t.hash();
+    };
+};
+
+/**
+ * Extend std::hash for PacketHeaderV4
+ */
+inline std::size_t hash_value(const PacketHeaderV4& t)
+{
+    return t.hash();
+}
 
 #endif //GWLBTUN_PACKETHEADERV4_H

--- a/PacketHeaderV6.cpp
+++ b/PacketHeaderV6.cpp
@@ -70,34 +70,6 @@ PacketHeaderV6::PacketHeaderV6(unsigned char *pktbuf, ssize_t pktlen)
 }
 
 /**
- * Compare if the headers in one packet match another. Meant to be used for the various sort and search functions.
- *
- * @param ph PacketHeaderV4 to compare againgst.
- * @return true if PacketHeaders are the same, false otherwise.
- */
-bool PacketHeaderV6::operator==(const PacketHeaderV6 &ph) const
-{
-#ifdef HASH_IS_SYMMETRICAL
-    return prot == ph.prot &&
-           ((srcpt == ph.srcpt && dstpt == ph.dstpt && !memcmp(&src, &ph.src, sizeof(struct in6_addr)) && !memcmp(&dst, &ph.dst, sizeof(struct in6_addr))) ||
-            (srcpt == ph.dstpt && dstpt == ph.srcpt && !memcmp(&src, &ph.dst, sizeof(struct in6_addr)) && !memcmp(&dst, &ph.src, sizeof(struct in6_addr))));
-#else
-    return prot == ph.prot &&  srcpt == ph.srcpt && dstpt == ph.dstpt &&
-        !memcmp(&src, &ph.src, sizeof(struct in6_addr)) && !memcmp(&dst, &ph.dst, sizeof(struct in6_addr));
-#endif
-}
-
-/**
- * Returns a hash value based on the protocol data.
- *
- * @return Hash value.
- */
-std::size_t PacketHeaderV6::hash() const
-{
-    return hashFunc(prot, (void *)&src, (void *)&dst, 16, srcpt, dstpt);
-}
-
-/**
  * Returns a string with the contents of the PacketHeaderV4 for human consumption.
  *
  * @return The string.
@@ -135,16 +107,3 @@ std::ostream &operator<<(std::ostream &os, PacketHeaderV6 const &m)
 {
     return os << m.text();
 }
-
-/**
- * Extend std::hash for PacketHeaderV6
- */
-std::size_t std::hash<PacketHeaderV6>::operator()(const PacketHeaderV6& t) const
-{
-    return t.hash();
-};
-
-std::size_t hash_value(const PacketHeaderV6& t)
-{
-    return t.hash();
-};

--- a/PacketHeaderV6.h
+++ b/PacketHeaderV6.h
@@ -11,13 +11,35 @@
 #include <iostream>
 #include <stdexcept>
 #include <netinet/ip6.h>
+#include "utils.h"
 
 class PacketHeaderV6 {
 public:
     PacketHeaderV6(unsigned char *pktbuf, ssize_t pktlen);   // pktbuf points to the start of the IP header.
-    bool operator==(const PacketHeaderV6 &) const;
+    
+    bool operator==(const PacketHeaderV6 &ph) const
+    {
+    #ifdef HASH_IS_SYMMETRICAL
+        return prot == ph.prot &&
+            ((srcpt == ph.srcpt && dstpt == ph.dstpt && !memcmp(&src, &ph.src, sizeof(struct in6_addr)) && !memcmp(&dst, &ph.dst, sizeof(struct in6_addr))) ||
+                (srcpt == ph.dstpt && dstpt == ph.srcpt && !memcmp(&src, &ph.dst, sizeof(struct in6_addr)) && !memcmp(&dst, &ph.src, sizeof(struct in6_addr))));
+    #else
+        return prot == ph.prot &&  srcpt == ph.srcpt && dstpt == ph.dstpt &&
+            !memcmp(&src, &ph.src, sizeof(struct in6_addr)) && !memcmp(&dst, &ph.dst, sizeof(struct in6_addr));
+    #endif
+    }
+
+    /**
+    * Returns a hash value based on the protocol data.
+    *
+    * @return Hash value.
+    */
+    std::size_t hash() const
+    {
+        return hashFunc(prot, (void *)&src, (void *)&dst, 16, srcpt, dstpt);
+    }
+
     std::string text() const;
-    std::size_t hash() const;
 
 private:
     struct in6_addr src;
@@ -29,7 +51,16 @@ private:
 };
 
 std::ostream &operator<<(std::ostream &os, PacketHeaderV6 const &m);
-template<> struct std::hash<PacketHeaderV6>:unary_function<PacketHeaderV6, size_t> { std::size_t operator()(const PacketHeaderV6& t) const; };
-std::size_t hash_value(const PacketHeaderV6& t);
+
+template<> struct std::hash<PacketHeaderV6>:unary_function<PacketHeaderV6, size_t> { 
+    std::size_t operator()(const PacketHeaderV6& t) const
+    {
+        return t.hash();
+    };
+ };
+
+inline std::size_t hash_value(const PacketHeaderV6& t) {
+    return t.hash();
+}
 
 #endif //GWLBTUN_PACKETHEADERV6_H


### PR DESCRIPTION
Addresses a few performance bottlenecks in the hot path of packet processing. Based on my profiling this makes the actual handling of the packet (the flow cache writes and tun device writes) go from 37% of the total per-packet time -> 53% of the total on the upload path.

<img width="1056" height="641" alt="image" src="https://github.com/user-attachments/assets/e0c066cb-14b1-4df4-b164-51418351b0c8" />

In terms of actual performance this significantly reduced tail latency in high throughput scenarios, especially during high upload PPS.

A summarization of performance improvements:
- Keep a thread-local cache of ENI -> GeneveHandler for non-blocking lookups in the hot path
- Change GwlbData header to a boost::container::small_vector pre-allocated to 40 bytes
- In GwlbData only store the header instead of the full GenevePacket as nothing but the header was being used. Re-construct GenevePacket if needed for text debugging. This reduces the amount of copying and construction that happens between methods
- Remove parsing+storing of individual GeneveOptions from the GenevePacket and omit storing the header entirely, only the bits useful for debugging, removing an entire complex allocation and resizing of a vector for the 3 options never used.
- Move PacketHeader hash + comparison to header file for better compiler inlining
- In general reduce the amount of allocations/copies by using std::move where applicable